### PR TITLE
Add build/* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ website/translated_docs
 website/build/
 website/node_modules
 website/i18n/*
+
+build/*


### PR DESCRIPTION
## Changes:

- Add `build/*` to `.gitignore`

## Context:

When you run the `yarn run build` command you get a folder `build/`. Git should ignore this folder.