### PR TITLE
Capitalize proper noun JavaScript

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -42,13 +42,13 @@ When you get a zip file source, you can debug the source locally by following th
 3. Check the URL where the server is started and open
    [`http://localhost:8080/iframe.html`](http://localhost:8080/iframe.html) in
    your browser (replace `8080` with the port used for your server).
-4. Wait for the page to load, then open up a javascript console and run
+4. Wait for the page to load, then open up a JavaScript console and run
    `window.happo.nextExample()`.
 5. See your first component load.
 6. Keep calling `window.happo.nextExample()` to iterate through your components.
 
 If you quickly want to iterate through all components, copy and paste this
-script in the javascript console:
+script in the JavaScript console:
 
 ```js
 var renderIter = function() {

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -3,7 +3,7 @@ id: examples
 title: Happo Examples
 ---
 
-This page outlines how to integrate Happo with an existing javascript codebase
+This page outlines how to integrate Happo with an existing JavaScript codebase
 through the use of "example" files scattered throughout your project. Both
 React and plain JS can be used here. Control what type you're using through
 [the `type` configuration option](configuration.md#type).
@@ -427,7 +427,7 @@ Examples can reference images in a few different ways:
 Happo works best when CSS code is co-located with the components. In some
 cases, you'll get away with zero configuration to get this working. But in other
 cases, you'll have to add a little webpack config to the mix. Happo uses
-webpack under the hood when generating browser-executable javascript. The
+webpack under the hood when generating browser-executable JavaScript. The
 [`customizeWebpackConfig` config
 option](configuration.md#customizeWebpackConfig) will let you inject things
 like webpack loaders to the happo run. E.g.

--- a/docs/spurious-diffs.md
+++ b/docs/spurious-diffs.md
@@ -34,7 +34,7 @@ dealing with spurious diffs:
 - If a component depends on external data (via some API), consider splitting
   out the data-fetching from the component and test the component without data
   fetching, injecting the data needed to render it.
-- If you have animations controlled from javascript, find a way to disable them
+- If you have animations controlled from JavaScript, find a way to disable them
   for the Happo test suite.
 - If individual elements are known to cause spuriousness, consider adding the
   `data-happo-hide` attribute. This will render the element invisible in the

--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -326,8 +326,8 @@ you can follow these steps:
 1. In a browser, go to the storybook URL. E.g. http://localhost:3000
 2. The URL will change to something like http://localhost:3000/?selectedKind=foo&selectedStory=default
 3. Change the URL to point to `/iframe.html`, e.g. http://localhost:3000/iframe.html
-4. Open the javascript console
-5. Paste this javascript snippet and hit enter: `happo.nextExample().then((item) => console.log(item))`
+4. Open the JavaScript console
+5. Paste this JavaScript snippet and hit enter: `happo.nextExample().then((item) => console.log(item))`
 6. Run that code again repeatedly to step through each example (use the arrow up key to reuse the last command)
 
 To quickly run through all examples, follow steps 1-4, then paste this script instead:


### PR DESCRIPTION
## Changes:

- Capitalize the word JavaScript

## Context:

JavaScript is a proper noun, and should be capitalized.