### PR TITLE
Add documentation for stabilizing stack traces in spurious diffs

### DIFF
--- a/docs/spurious-diffs.md
+++ b/docs/spurious-diffs.md
@@ -14,6 +14,7 @@ These involve (but are not limited to):
 - animations
 - random data, counters, etc
 - dates, timestamps, etc
+- stack traces
 
 Happo tries to take care of as many of these as possible, automatically. For
 instance, the following tasks are performed before taking the screenshot:
@@ -24,20 +25,64 @@ instance, the following tasks are performed before taking the screenshot:
 - disable CSS animations/transitions
 - stop SVG animations
 
+## Tips & tricks
+
 In some cases however, Happo can't automatically detect things that cause
 spuriousness. Here are some tips & tricks that you might find useful when
-dealing with spurious diffs:
+dealing with spurious diffs.
 
-- If you have dates/timestamps, either injecting a fixed
-  `new Date('2019-05-23T08:28:02.446Z')` into your component or freezing time
-  via something like [mockdate](https://www.npmjs.com/package/mockdate) or
-  [Sinon.js](https://sinonjs.org/) can help.
-- If a component depends on external data (via some API), consider splitting out
-  the data-fetching from the component and test the component without data
-  fetching, injecting the data needed to render it.
-- If you have animations controlled from JavaScript, find a way to disable them
-  for the Happo test suite.
-- If individual elements are known to cause spuriousness,
-  [consider adding the `data-happo-hide` attribute](hiding-content.md). This
-  will render the element invisible in the screenshot. E.g.
-  `<div data-happo-hide>{Math.random()}</div>`.
+### Dates and timestamps
+
+If you have dates/timestamps, either injecting a fixed
+`new Date('2019-05-23T08:28:02.446Z')` into your component or freezing time via
+something like [mockdate](https://www.npmjs.com/package/mockdate) or
+[Sinon.js](https://sinonjs.org/) can help.
+
+### External data
+
+If a component depends on external data (via some API), consider splitting out
+the data-fetching from the component and test the component without data
+fetching, injecting the data needed to render it.
+
+### Animations
+
+If you have animations controlled from JavaScript, find a way to disable them
+for the Happo test suite.
+
+### Stack traces
+
+If you have components that throw errors, consider catching them and rendering a
+normalized error message. This is especially useful if you have components that
+render stack traces, which are likely to change between test runs.
+
+One way to normalize these stack traces in a React component is to use an error
+boundary. Here's an example:
+
+```jsx
+import { ErrorBoundary } from 'react-error-boundary';
+
+// https://github.com/bvaughn/react-error-boundary?tab=readme-ov-file#errorboundary-with-fallbackrender-prop
+const fallbackRender = ({ error }) => {
+  // We need to sanitize ports, asset hashes, and line/col numbers from
+  // the stack trace to make the Happo diffs stabilized.
+  error.stack = error.stack.replace(
+    /http:\/\/localhost:\d{4}.*?:\d+:\d+/g,
+    'http://localhost:1234/path-to-file.1234abcd.bundle.js:1234:56',
+  );
+
+  throw error;
+};
+
+export const MiscFailing = () => (
+  <ErrorBoundary fallbackRender={fallbackRender}>
+    <ComponentThatThrows />
+  </ErrorBoundary>
+);
+```
+
+### Hiding content with `data-happo-hide`
+
+If individual elements are known to cause spuriousness,
+[consider adding the `data-happo-hide` attribute](hiding-content.md). This will
+render the element invisible in the screenshot. E.g.
+`<div data-happo-hide>{Math.random()}</div>`.


### PR DESCRIPTION
I noticed that some customers were seeing spurious diffs due to stack traces changing all of the time. I'd like to send them some advice on how to fix this, so I figured this is a good opportunity to improve our documentation.

To make this document easier to expand, I changed the bulleted list to a section with headings. This will make it easier for us to add more code examples in the future.