### PR TITLE
Stop using deprecated docker image in publish-docker job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,7 @@ jobs:
       - image: circleci/buildpack-deps:stretch
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 20.10.14
+      - setup_remote_docker
       - run:
           name: Publish Docker image
           command: |


### PR DESCRIPTION
I noticed a deprecation warning that linked to this page:

https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176

It looks like this will start failing on September 30, so we need to update now.

I decided to go with the default version, which is currently v24 and should always stay up to date. This matches what we do in happo-view.