### PR TITLE
Build and serve local docker in prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ RUN yarn build
 
 EXPOSE 3344
 
-CMD ["yarn", "start", "--no-watch", "--port", "3344"]
+CMD ["yarn", "serve", "--port", "3344"]

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "examples": "docusaurus-examples",
     "start": "docusaurus start",
+    "serve": "docusaurus serve",
     "build": "docusaurus build",
     "publish-gh-pages": "docusaurus publish",
     "write-translations": "docusaurus write-translations",


### PR DESCRIPTION
I updated our cluster to run v3 of docusaurus but ran into issues with starting the server. The main issue was that --no-watch was no longer supported and in the process I found that serving the static build is a better option than runnind `docusaurus start`.