### PR TITLE
Change some references of master to main

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -261,10 +261,10 @@ the system mouse pointer:
 }
 ```
 
-If you rely on mouse interaction in your tests, e.g. when using [Storybook
-interactive stories](storybook.md#overriding-the-default-render-timeout), you
-might have to tell Happo to skip injecting the pointer-event css block. You can
-do that through the `allowPointerEvents` option.
+If you rely on mouse interaction in your tests, e.g. when using
+[Storybook interactive stories](storybook.md#overriding-the-default-render-timeout),
+you might have to tell Happo to skip injecting the pointer-event css block. You
+can do that through the `allowPointerEvents` option.
 
 ```js
 // .happo.js
@@ -531,7 +531,7 @@ module.exports = {
 
 Happo uses jsdom internally. By default, it provides sane defaults to the
 `JSDOM` constructor. See
-[processSnapsInBundle.js](https://github.com/happo/happo.io/blob/master/src/processSnapsInBundle.js).
+[processSnapsInBundle.js](https://github.com/happo/happo.io/blob/main/src/processSnapsInBundle.js).
 You can override any options here but your mileage may vary. See
 https://github.com/jsdom/jsdom#simple-options. Here's an example where the
 document's `referrer` is being set:

--- a/docs/cypress.md
+++ b/docs/cypress.md
@@ -309,8 +309,8 @@ If you run the test suite in a CI environment, the `happo-cypress` and
 `happo-e2e` modules will do their best to auto-detect your environment and adapt
 its behavior accordingly:
 
-- On PR builds, compare the screenshots against the master branch
-- On master builds, simply create the Happo report
+- On PR builds, compare the screenshots against the `main` branch
+- On `main` branch builds, simply create the Happo report
 
 To get the results of the Happo jobs back to your PRs/commits, you need to
 install and configure the Happo GitHub app. Instructions are available
@@ -327,11 +327,11 @@ If you are using a different CI service, you'll have to set a few environment
 variables before invoking the test suite:
 
 - `HAPPO_PREVIOUS_SHA` the commit sha that the branch/PR is based on (usually a
-  commit on master). Only set this for PR builds.
+  commit on `main`). Only set this for PR builds.
 - `HAPPO_CURRENT_SHA` the sha of the commit currently under test. Always set
   this.
 - `HAPPO_BASE_BRANCH` the default/base branch you use, e.g. `origin/dev`.
-  Defaults to `origin/master`, so you only need to set this if you are using a
+  Defaults to `origin/main`, so you only need to set this if you are using a
   different base branch.
 - `HAPPO_CHANGE_URL` a url to the PR/commit. Optional.
 
@@ -345,13 +345,13 @@ workflow. It makes use of the
 name: Cypress with Happo workflow
 
 on:
-  # Configure this workflow to trigger on pull requests and pushes to master
+  # Configure this workflow to trigger on pull requests and pushes to main
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   cypress:
@@ -419,7 +419,7 @@ set up in your repository.
 
 ```yaml
 trigger:
-  - master
+  - main
 
 pool:
   vmImage: ubuntu-latest

--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -162,7 +162,6 @@ await happoPlaywright.screenshot(page, heroImage, {
 "Footer" is now rendered in Chrome (target specified in `.happo.js`) and Firefox
 (dynamic target).
 
-
 ## Continuous Integration
 
 If you run the test suite in a CI environment, the `happo-playwright` module
@@ -186,11 +185,11 @@ If you are using a different CI service, you'll have to set a few environment
 variables before invoking the test suite:
 
 - `HAPPO_PREVIOUS_SHA` the commit sha that the branch/PR is based on (usually a
-  commit on master). Only set this for PR builds.
+  commit on `main`). Only set this for PR builds.
 - `HAPPO_CURRENT_SHA` the sha of the commit currently under test. Always set
   this.
 - `HAPPO_BASE_BRANCH` the default/base branch you use, e.g. `origin/dev`.
-  Defaults to `origin/master`, so you only need to set this if you are using a
+  Defaults to `origin/main`, so you only need to set this if you are using a
   different base branch.
 - `HAPPO_CHANGE_URL` a url to the PR/commit. Optional.
 
@@ -270,8 +269,7 @@ happo-e2e finalize --skippedExamples '[{"component":"Button","variant":"default"
 
 Finding the skipped snapshots can be a little tricky, but a little bit of code
 introspection could help. Here's an example of a script that can serve as a
-base:
-https://github.com/happo/happo-e2e/issues/21#issuecomment-1825776491
+base: https://github.com/happo/happo-e2e/issues/21#issuecomment-1825776491
 
 ## Troubleshooting
 
@@ -307,5 +305,5 @@ happened:
   something like `#start-page .header { color: red }` and screenshoot `.header`,
   the red color will be missing. This is because Happo only sees the `.header`
   element, never the surrounding page.
-- There could be a bug in how `happo-e2e` collects styles and assets. Reach
-  out to support@happo.io and we'll triage.
+- There could be a bug in how `happo-e2e` collects styles and assets. Reach out
+  to support@happo.io and we'll triage.


### PR DESCRIPTION
In https://github.com/happo/happo-e2e/pull/40 we changed the fallback branch from origin/master to origin/main, so we need to update our docs for happo-e2e related things like cypress and playwright.

There are some other references to master in here, but I think they are still accurate based on the code in happo-ci-travis, so I am leaving them alone for now.