### PR TITLE
Change docker image from circleci to cimg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   publish-docker:
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: cimg/base:current
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
The old circleci images are deprecated. Switching to the new stuff.