### PR TITLE
Add syntax highlighting for a couple of code blocks

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -192,7 +192,7 @@ If set to `true`, this option will allow you to add `data-happo-hover` and
 `data-happo-focus` attributes to your DOM elements and have Happo apply either
 `:hover` or `:focus` styles. Let's say you have this markup:
 
-```
+```html
 <button>Hover me</button>
 <style>
   button:hover {
@@ -204,7 +204,7 @@ If set to `true`, this option will allow you to add `data-happo-hover` and
 If you want the hover style to be applied before taking the screenshot (making
 the button blue), you can change the markup to this:
 
-```
+```html
 <button data-happo-hover>Hover me</button>
 <style>
   button:hover {
@@ -215,8 +215,8 @@ the button blue), you can change the markup to this:
 
 Similar to hover, you can also add focus to elements using `data-happo-focus`:
 
-```
-<input type="text" data-happo-focus>
+```html
+<input type="text" data-happo-focus />
 ```
 
 ### Target `prefersReducedMotion`

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -22,7 +22,7 @@ isolated.
 
 Browsers perform differently. The fastest ones we have are Chrome and Firefox,
 capable of producing more than 10 screenshots per second. Other browsers are
-slightly slower and will max out at 5-10 screenshots per second.  Choose your
+slightly slower and will max out at 5-10 screenshots per second. Choose your
 [targets](configuration.md#targets) wisely as the performance of your test suite
 is mostly going to be decided by your slowest target. The (global) average time
 it takes to produce a screenshot on a Happo worker is 200 ms.

--- a/docs/storybook.md
+++ b/docs/storybook.md
@@ -379,7 +379,9 @@ import { userEvent } from '@storybook/testing-library';
 export const InteractiveStory = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.type(canvas.getByRole('textbox'), 'some longer text', { delay: 200 })  ;
+    await userEvent.type(canvas.getByRole('textbox'), 'some longer text', {
+      delay: 200,
+    });
   },
 };
 ```
@@ -387,7 +389,7 @@ export const InteractiveStory = {
 This story would take over 3 seconds to finish. To make happo wait that long,
 you can use `setRenderTimeoutMs` to increase the timeout.
 
-```
+```js
 // .storybook/preview.js
 import { setRenderTimeoutMs } from 'happo-plugin-storybook/register';
 
@@ -395,9 +397,10 @@ setRenderTimeoutMs(5000);
 ```
 
 Setting a longer timeout won't affect rendering times for fast/regular stories.
-It is only in effect if you use [the `play`
-function](https://storybook.js.org/docs/react/writing-stories/play-function) to
-do interactions, or if you use [`waitFor`](#waiting-for-a-condition-to-be-truthy) or
+It is only in effect if you use
+[the `play` function](https://storybook.js.org/docs/react/writing-stories/play-function)
+to do interactions, or if you use
+[`waitFor`](#waiting-for-a-condition-to-be-truthy) or
 [`waitForContent`](#waiting-for-content).
 
 ### The `beforeScreenshot` hook
@@ -465,10 +468,10 @@ Same as for `beforeScreenshot`, you can use `async` as well.
 
 If you are using the
 [play function ](https://storybook.js.org/docs/react/writing-stories/play-function)
-and the [Interactions
-addon](https://storybook.js.org/docs/react/essentials/interactions) you can
-force Happo to take screenshots of different steps along the way. Here's an
-example of a Dropdown story that we open and close in two different steps:
+and the
+[Interactions addon](https://storybook.js.org/docs/react/essentials/interactions)
+you can force Happo to take screenshots of different steps along the way. Here's
+an example of a Dropdown story that we open and close in two different steps:
 
 ```js
 import { forceHappoScreenshot } from 'happo-plugin-storybook/register';


### PR DESCRIPTION
I noticed that we didn't have any nice syntax highlighting in a couple of places. This should make the docs slightly nicer to read.

Prettier reformatted a couple of things while I was in here as well.