### PR TITLE
Update GitHub actions docs for checkout

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -152,6 +152,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 100
       - uses: actions/setup-node@v4
       - run: npm ci


### PR DESCRIPTION
Today we found and fixed a problem where pushing new commits on an old pull request produced diffs that used an after report that were newer than we expected. We figured out that this was because GitHub creates a synthetic merge commit that is fully rebased and checks that out by default. This caused the after report to be newer than it should have been.

The fix is to check out the HEAD SHA of the pull request instead.