### PR TITLE
Enable docker layer caching for publish docker job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,9 @@ jobs:
       - image: cimg/base:current
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          docker_layer_caching: true
+
       - run:
           name: Publish Docker image
           command: |


### PR DESCRIPTION
This should speed up the time it takes to get a release published.

More info:

https://circleci.com/docs/docker-layer-caching/