### PR TITLE
Replace "Recur AB" with "Happo LLC" in copyright notice

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -123,7 +123,7 @@ module.exports = {
         },
       ],
 
-      copyright: `Copyright © ${new Date().getFullYear()} Recur AB`,
+      copyright: `Copyright © ${new Date().getFullYear()} Happo LLC`,
     },
   },
 };

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -1,6 +1,6 @@
 {
   "copyright": {
-    "message": "Copyright © 2024 Recur AB",
+    "message": "Copyright © 2024 Happo LLC",
     "description": "The footer copyright"
   }
 }


### PR DESCRIPTION
This updates the company name.