### PR TITLE
Run as non-root user and use node:22-slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,27 @@
-FROM node:22.11.0
+FROM node:22-slim
 
 WORKDIR /app
 
-COPY ./package.json ./yarn.lock /app/
+# Set up a non-root user to run as
+ARG user=pod_user
+ARG group=pod_user
+ARG uid=950
+ARG gid=950
+RUN groupadd --gid ${gid} ${group} \
+    && useradd --uid ${uid} \
+        --gid ${gid} ${user} \
+        --system \
+        --shell /bin/sh \
+        --create-home --home-dir /home/${user} \
+    && chown --recursive ${user}:${group} /tmp /app /home/${user}
+
+# Switch to the non-root user
+USER ${user}
+
+COPY --chown=${user}:${group} package.json yarn.lock /app/
 RUN yarn install
 
-COPY ./ /app/
+COPY --chown=${user}:${group} . /app/
 
 RUN yarn build
 


### PR DESCRIPTION
This improves our security posture.