### PR TITLE
Change beforeAll call in Playwright docs

### DIFF
--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -32,8 +32,8 @@ for initialization and an `afterAll` hook to finish the happo session.
 ```js
 const happoPlaywright = require('happo-playwright');
 
-test.beforeAll(async ({ context }) => {
-  await happoPlaywright.init(context);
+test.beforeAll(async () => {
+  await happoPlaywright.init();
 });
 
 test.afterAll(async () => {


### PR DESCRIPTION
Since version 2.2.0 we no longer have to pass the context to the init call. This will simplify setup since context isn't directly available in a beforeAll hook.