### PR TITLE
Add yarn examples for `--allow-failures`

### DIFF
--- a/docs/cypress.md
+++ b/docs/cypress.md
@@ -184,6 +184,12 @@ fails. The `--allow-failures` flag for the `happo-e2e` command can then be used:
 npx happo-e2e --allow-failures -- npx cypress run
 ```
 
+If you're using `yarn`, you might need to pass the double dashes twice, like so:
+
+```sh
+yarn happo-e2e -- --allow-failures -- yarn cypress run
+```
+
 ## Selecting targets
 
 If you want to avoid rendering an example in all browser targets (found in

--- a/docs/playwright.md
+++ b/docs/playwright.md
@@ -112,6 +112,12 @@ fails. The `--allow-failures` flag for the `happo-e2e` command can then be used:
 npx happo-e2e --allow-failures -- npx playwright test
 ```
 
+If you're using `yarn`, you might need to pass the double dashes twice, like so:
+
+```sh
+yarn happo-e2e -- --allow-failures -- yarn playwright test
+```
+
 ## Selecting targets
 
 If you want to avoid rendering an example in all browser targets (found in


### PR DESCRIPTION
The placement of the double dashes is a bit confusing, so having some clear examples here will be helpful for folks.