### PR TITLE
Add babel group to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     schedule:
       interval: daily
     groups:
+      babel:
+        patterns:
+          - '@babel/*'
+          - 'babel*'
       docusaurus:
         patterns:
           - '@docusaurus/*'


### PR DESCRIPTION
I didn't think to add this because we don't have babel dependencies directly, but we recently had a few separate PRs to update babel dependencies, because they are pulled in transitively and had some security fixes. Adding this config will reduce the number of PRs we have to deal with here and help all of the babel deps be updated together.