### PR TITLE
Change fetch-depth from 100 to 0 in CI docs for GitHub Actions

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-          fetch-depth: 100
+          fetch-depth: 0
       - uses: actions/setup-node@v4
       - run: npm ci
       - run: npx --package=happo.io happo-ci-github-actions


### PR DESCRIPTION
The new version of the happo.io package runs git merge-base to find the previous SHA, so we need to be able to find the origin/main branch. Using a fetch-depth of 0 accomplishes this.