### PR TITLE
Update GitHub actions example to use fetch-depth: 100 and git fetch

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -63,7 +63,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-          fetch-depth: 0
+          fetch-depth: 100
+      - run: git fetch origin main:main
       - uses: actions/setup-node@v4
       - run: npm ci
       - run: npx --package=happo.io happo-ci-github-actions


### PR DESCRIPTION
This should be a more efficient method, so I think it makes sense to recommend it as the default way for people to integrate with GitHub actions.