### PR TITLE
Update GitHub actions instructions for fetching main branch

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -64,7 +64,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 100
-      - run: git fetch origin main:main
+      - name: Fetch main branch
+        if: github.ref != 'refs/heads/main'
+        run: git fetch origin main:main
       - uses: actions/setup-node@v4
       - run: npm ci
       - run: npx --package=happo.io happo-ci-github-actions


### PR DESCRIPTION
I ran into an issue with this today and I think we need to skip this step on the main branch.

https://github.com/happo/happo-plugin-storybook/pull/219