### PR TITLE
Fix broken links

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -16,8 +16,8 @@ let you know exactly what has changed in your UI.
 
 > The instructions on this page apply to all integrations except the Cypress and
 > Playwright integrations. Refer to
-> [the Cypress integration page](cypress.md#continuous-integration) and
-> [the Playwright integration page](playwright.md#continuous-integration) for
+> [the Cypress integration page](cypress.mdx#continuous-integration) and
+> [the Playwright integration page](playwright.mdx#continuous-integration) for
 > instructions on how to integrate with CI there.
 
 To simplify using Happo in a pull-request/merge-request model, Happo provides a

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -23,13 +23,13 @@ and there are a few buttons here that can be useful. Depending on the type of
 integration you are using, you'll see one or more of these buttons:
 
 - A "View recorded HTML" button (for [Happo Examples](examples.md) and
-  [Cypress setups](cypress.md)) that allow you to see the rendered HTML directly
-  in the browser, along with the CSS used.
+  [Cypress setups](cypress.mdx)) that allow you to see the rendered HTML
+  directly in the browser, along with the CSS used.
 - A "Download assets" button, where you can grab the images, fonts, etc, that
   were used when taking the screenshot.
 - A "Download static package" button that let's you fetch the statically built
   package used to render the example. This will e.g. show up if you're using
-  [Storybook](storybook.md), or if you're using [Happo Examples](examples.md)
+  [Storybook](storybook.mdx), or if you're using [Happo Examples](examples.md)
   with the `prerender: false` option.
 - A "Re-generate snapshot" button, that will let you retry taking the
   screenshot. Continue reading for more on this option!
@@ -174,7 +174,7 @@ click on the one that has a failure icon.
 
 ### `Timed out while waiting for window.happo`
 
-A common error when using [the Storybook integration](storybook.md) is
+A common error when using [the Storybook integration](storybook.mdx) is
 `Timed out while waiting for window.happo`. This is often caused by missing to
 register the `happo-plugin-storybook` plugin. See how to get rid of this in
-[the Storybook docs](storybook.md#troubleshooting).
+[the Storybook docs](storybook.mdx#troubleshooting).

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -22,15 +22,15 @@ consists of a set of components and variants of those components. There are many
 ways to do this, and it all depends on your existing tech stack, your
 application, experience with other test frameworks, and more.
 
-- A [Storybook](storybook.md) application can serve as the test suite driver for
+- A [Storybook](storybook.mdx) application can serve as the test suite driver for
   Happo.
-- By integrating Happo with [Cypress](cypress.md) or
-  [Playwright](playwright.md), you can turn your end-to-end tests into a Happo
+- By integrating Happo with [Cypress](cypress.mdx) or
+  [Playwright](playwright.mdx), you can turn your end-to-end tests into a Happo
   test suite.
 - If you want to test an existing (public) website, you can use
-  [the `pages` option](full-page.md).
+  [the `pages` option](full-page.mdx).
 - If you want to create a custom test suite for React or another JS framework,
-  you can use the [Custom bundle integration](custom.md).
+  you can use the [Custom bundle integration](custom.mdx).
 - For native apps and others not running in a browser, use [the API](native.md)
   directly.
 

--- a/docs/migrating-from-legacy-packages.md
+++ b/docs/migrating-from-legacy-packages.md
@@ -493,7 +493,7 @@ integration type (originally in the `happo-static` package).
 This puts the bundling and rendering of the examples to the DOM completely in
 your control. If you are using the legacy Happo examples integration, you will
 need to convert these to a Happo custom type. Follow the
-[Happo Custom integration documentation](custom.md).
+[Happo Custom integration documentation](custom.mdx).
 
 ### E2E Command Changes
 

--- a/versioned_docs/version-legacy/configuration.md
+++ b/versioned_docs/version-legacy/configuration.md
@@ -297,7 +297,7 @@ the system mouse pointer:
 ```
 
 If you rely on mouse interaction in your tests (e.g., when using
-[Storybook interactive stories](storybook.md#overriding-the-default-render-timeout)),
+[Storybook interactive stories](storybook.mdx#overriding-the-default-render-timeout)),
 you might see an error like this in your logs:
 
 > Error: Unable to perform pointer interaction as the element has
@@ -340,7 +340,7 @@ project will be used.
 ## `include`
 
 > This option only applies when using
-> [the Happo Examples integration](examples.md)
+> [the Happo Examples integration](examples.mdx)
 
 Controls which files Happo will extract examples from. The default is
 `'**/@(*-happo|happo).@(js|jsx)'`. This option is useful if you want to apply a
@@ -349,7 +349,7 @@ different naming scheme, such as `**/*-examples.js`.
 ## `stylesheets`
 
 > This option only applies when using
-> [the Happo Examples integration](examples.md)
+> [the Happo Examples integration](examples.mdx)
 
 If you rely on external stylesheets, list their URLs or absolute file paths in
 this config option, such as `['/path/to/file.css', 'http://cdn/style.css']`. If
@@ -373,7 +373,7 @@ receive styles from that stylesheet.
 ## `type`
 
 > This option only applies when using
-> [the Happo Examples integration](examples.md)
+> [the Happo Examples integration](examples.mdx)
 
 Either `react` (default) or `plain`. Determines the strategy Happo will use when
 rendering examples. When set to `react`, example functions are expected to
@@ -384,7 +384,7 @@ return a React component (e.g., `export default () => <Foo />`). When set to
 ## `customizeWebpackConfig`
 
 > This option only applies when using
-> [the Happo Examples integration](examples.md)
+> [the Happo Examples integration](examples.mdx)
 
 A function you can use to override or modify the default webpack config used
 internally by Happo during a run. **Always return the passed `config`.** For
@@ -449,7 +449,7 @@ module.exports = {
 ## `publicFolders`
 
 > This option only applies when using
-> [the Happo Examples integration](examples.md)
+> [the Happo Examples integration](examples.mdx)
 
 An array of absolute paths specifying where public assets are located. Useful if
 you have examples that depend on publicly available images (e.g.,
@@ -466,7 +466,7 @@ module.exports = {
 ## `prerender`
 
 > This option only applies when using
-> [the Happo Examples integration](examples.md)
+> [the Happo Examples integration](examples.mdx)
 
 Controls whether examples are pre-rendered in a JSDOM environment (or Chrome if
 you're using
@@ -504,7 +504,7 @@ so ensure it's unique for each page.
 ## `setupScript`
 
 > This option only applies when using
-> [the Happo Examples integration](examples.md)
+> [the Happo Examples integration](examples.mdx)
 
 An absolute path to a file that will be executed before rendering your
 components. This is useful if you want to inject global CSS styling (e.g., a CSS
@@ -522,7 +522,7 @@ module.exports = {
 ## `renderWrapperModule`
 
 > This option only applies when using
-> [the Happo Examples integration](examples.md)
+> [the Happo Examples integration](examples.mdx)
 
 An absolute path to a file exporting a function where you can wrap the rendering
 of Happo examples. This is useful if you have a theme provider or store
@@ -548,7 +548,7 @@ export default component => <ThemeProvider>{component}</ThemeProvider>;
 ## `rootElementSelector`
 
 > This option only applies when using
-> [the Happo Examples integration](examples.md)
+> [the Happo Examples integration](examples.mdx)
 
 A selector used to find a DOM element that Happo will use as the container. In
 most cases, leave this empty and let Happo determine the root element
@@ -580,7 +580,7 @@ module.exports = {
 ## `jsdomOptions`
 
 > This option only applies when using
-> [the Happo Examples integration](examples.md)
+> [the Happo Examples integration](examples.mdx)
 
 Happo uses jsdom internally. By default, it provides sensible defaults to the
 `JSDOM` constructor. See
@@ -633,7 +633,7 @@ output to determine what threshold value you want to use.
 ## `asyncTimeout`
 
 > This option only applies when using
-> [the Happo Examples integration](examples.md)
+> [the Happo Examples integration](examples.mdx)
 
 If an example renders nothing to the DOM, Happo will wait a short while for
 content to appear. Specified in milliseconds, the default is `200`.

--- a/versioned_docs/version-legacy/continuous-integration.md
+++ b/versioned_docs/version-legacy/continuous-integration.md
@@ -16,7 +16,7 @@ let you know exactly what has changed in your UI.
 
 > The instructions on this page apply to all integrations except the Cypress and
 > Playwright integrations. Refer to
-> [the Cypress integration page](cypress.md#continuous-integration) and
+> [the Cypress integration page](cypress.mdx#continuous-integration) and
 > [the Playwright integration page](playwright.md#continuous-integration) for
 > instructions on how to integrate with CI there.
 

--- a/versioned_docs/version-legacy/debugging.md
+++ b/versioned_docs/version-legacy/debugging.md
@@ -22,14 +22,14 @@ The Source page has some details about what was used to produce the screenshot,
 and there are a few buttons here that can be useful. Depending on the type of
 integration you are using, you'll see one or more of these buttons:
 
-- A "View recorded HTML" button (for [Happo Examples](examples.md) and
-  [Cypress setups](cypress.md)) that allow you to see the rendered HTML directly
+- A "View recorded HTML" button (for [Happo Examples](examples.mdx) and
+  [Cypress setups](cypress.mdx)) that allow you to see the rendered HTML directly
   in the browser, along with the CSS used.
 - A "Download assets" button, where you can grab the images, fonts, etc, that
   were used when taking the screenshot.
 - A "Download static package" button that let's you fetch the statically built
   package used to render the example. This will e.g. show up if you're using
-  [Storybook](storybook.md), or if you're using [Happo Examples](examples.md)
+  [Storybook](storybook.mdx), or if you're using [Happo Examples](examples.mdx)
   with the `prerender: false` option.
 - A "Re-generate snapshot" button, that will let you retry taking the
   screenshot. Continue reading for more on this option!
@@ -100,7 +100,7 @@ click on the one that has a failure icon.
 
 ### `Timed out while waiting for window.happo`
 
-A common error when using [the Storybook integration](storybook.md) is
+A common error when using [the Storybook integration](storybook.mdx) is
 `Timed out while waiting for window.happo`. This is often caused by missing to
 register the `happo-plugin-storybook` plugin. See how to get rid of this in
-[the Storybook docs](storybook.md#troubleshooting).
+[the Storybook docs](storybook.mdx#troubleshooting).

--- a/versioned_docs/version-legacy/getting-started.md
+++ b/versioned_docs/version-legacy/getting-started.md
@@ -16,17 +16,17 @@ consists of a set of components and variants of those components. There are many
 ways to do this, and it all depends on your existing tech stack, your
 application, experience with other test frameworks, and more.
 
-- A [Storybook](storybook.md) application can serve as the test suite driver for
+- A [Storybook](storybook.mdx) application can serve as the test suite driver for
   Happo.
 - By using the [Static bundle integration](static.md), you can bring your own
   javascript bundle and have full control over the build phase and execution.
-- By integrating Happo with [Cypress](cypress.md) or
+- By integrating Happo with [Cypress](cypress.mdx) or
   [Playwright](playwright.md), you can turn your end-to-end tests into a Happo
   test suite.
 - If you want to test an existing (public) website, you can use
   [the `pages` option](full-page.md).
 - If you want to create a custom test suite for React or other js framework
-  apps, you can use [Happo Examples](examples.md).
+  apps, you can use [Happo Examples](examples.mdx).
 - For native apps and others not running in a browser, use [the API](native.md)
   directly.
 

--- a/versioned_docs/version-legacy/plugins.md
+++ b/versioned_docs/version-legacy/plugins.md
@@ -11,7 +11,7 @@ a list of officially supported plugins.
 
 The Happo plugin for [Storybook](https://storybook.js.org/) will automatically
 turn your stories into Happo examples. See the
-[Storybook integration page](storybook.md) for a full introduction.
+[Storybook integration page](storybook.mdx) for a full introduction.
 
 ```bash
 npm install --save-dev happo-plugin-storybook
@@ -79,7 +79,7 @@ module.exports {
 
 ## Scraping
 
-> The scrape plugin is deprecated. Use [the Cypress integration](cypress.md)
+> The scrape plugin is deprecated. Use [the Cypress integration](cypress.mdx)
 > instead.
 
 The Happo "scrape" plugin will make it possible to grab Happo examples from an
@@ -89,7 +89,7 @@ also check out the built-in [full-page support](#full-page-support).
 ## Gatsby
 
 > The Gatsby plugin is not under active development. Try using
-> [the Cypress integration](cypress.md) instead.
+> [the Cypress integration](cypress.mdx) instead.
 
 The Happo plugin for [Gatsby](https://www.gatsbyjs.org/) turns all your static
 pages into Happo tests. See https://github.com/happo/happo-plugin-gatsby.


### PR DESCRIPTION
It looks like when we converted some pages from .md to .mdx we inadvertantly broke a bunch of links.

Fixes #277