### PR TITLE
Add package metadata, e.g. private:true

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,9 @@
 {
+  "name": "docs",
+  "repository": "git@github.com:happo/docs.git",
+  "author": "Henric Persson <henric.trotzig@gmail.com>",
+  "license": "proprietary",
+  "private": true,
   "scripts": {
     "build": "docusaurus build",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
This will prevent release-with-ease from thinking it can publish the project to npmjs.