### PR TITLE
ci: skip Happo components for untouched docs pages

### DIFF
--- a/.github/workflows/happo.yml
+++ b/.github/workflows/happo.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -28,8 +30,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Fetch base branch
+        run: git fetch --no-tags --depth=0 origin main
+
       - name: Run Happo
         env:
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
-        run: pnpm happo
+        run: node runHappo.mjs

--- a/.github/workflows/happo.yml
+++ b/.github/workflows/happo.yml
@@ -31,7 +31,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Fetch base branch
-        run: git fetch --no-tags --depth=0 origin main
+        run: git fetch --no-tags origin main
 
       - name: Run Happo
         env:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "esbuild": "^0.28.0",
-    "happo": "6.10.2",
+    "happo": "6.10.7",
     "prettier": "3.8.3",
     "release-with-ease": "^2.2.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: ^0.28.0
         version: 0.28.0
       happo:
-        specifier: 6.10.2
-        version: 6.10.2
+        specifier: 6.10.7
+        version: 6.10.7
       prettier:
         specifier: 3.8.3
         version: 3.8.3
@@ -3272,8 +3272,8 @@ packages:
   handle-thing@2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
 
-  happo@6.10.2:
-    resolution: {integrity: sha512-V7FGLuPsJHku5FirATk9+24hlw/RpAwjM7DVS+1HjVg4vWKBWN9KF/t8XxNJcpGn50YzH1+nE7UDjAi6szCKfw==}
+  happo@6.10.7:
+    resolution: {integrity: sha512-H+2V20qnW7blxDImlljbB7no1ut69sIGOvDfjrJD0f/YLjSmgIy6LazFeSFNuSdt1nO2KjLwaSiTg1os19qEnA==}
     engines: {node: ^22.18.0 || ^23.6.0 || >=24.0.0}
     hasBin: true
 
@@ -9817,7 +9817,7 @@ snapshots:
 
   handle-thing@2.0.1: {}
 
-  happo@6.10.2:
+  happo@6.10.7:
     dependencies:
       async-retry: 1.3.3
       base64-stream: 1.0.0

--- a/runHappo.mjs
+++ b/runHappo.mjs
@@ -1,0 +1,128 @@
+import { execSync, spawn } from 'node:child_process';
+import fs from 'node:fs';
+
+const BASE_BRANCH = process.env.HAPPO_BASE_BRANCH || 'origin/main';
+
+function getChangedFiles() {
+  try {
+    const out = execSync(`git diff --name-only ${BASE_BRANCH}...HEAD`, {
+      encoding: 'utf-8',
+    });
+    return out
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean);
+  } catch (error) {
+    console.warn(
+      `Unable to compute changed files against ${BASE_BRANCH}: ${error.message}`,
+    );
+    return null;
+  }
+}
+
+function fileToComponent(file) {
+  if (/(?:^|\/)_partials\//.test(file)) {
+    return 'unknown';
+  }
+
+  const docsMatch = file.match(/^docs\/(.+)\.mdx?$/);
+  if (docsMatch) {
+    return `docs/${docsMatch[1]}`;
+  }
+
+  const versionedMatch = file.match(
+    /^versioned_docs\/version-([^/]+)\/(.+)\.mdx?$/,
+  );
+  if (versionedMatch) {
+    return `docs/${versionedMatch[1]}/${versionedMatch[2]}`;
+  }
+
+  return 'unknown';
+}
+
+async function enumerateSourceComponents() {
+  const components = [];
+
+  for await (const file of fs.promises.glob('docs/**/*.{md,mdx}')) {
+    if (/(?:^|\/)_partials\//.test(file)) continue;
+    const match = file.match(/^docs\/(.+)\.mdx?$/);
+    if (match) components.push(`docs/${match[1]}`);
+  }
+
+  for await (const file of fs.promises.glob(
+    'versioned_docs/version-*/**/*.{md,mdx}',
+  )) {
+    if (/(?:^|\/)_partials\//.test(file)) continue;
+    const match = file.match(
+      /^versioned_docs\/version-([^/]+)\/(.+)\.mdx?$/,
+    );
+    if (match) components.push(`docs/${match[1]}/${match[2]}`);
+  }
+
+  return components;
+}
+
+async function computeSkipList() {
+  const changed = getChangedFiles();
+
+  if (changed === null) {
+    console.log('Could not determine changed files; running all components.');
+    return null;
+  }
+
+  if (changed.length === 0) {
+    console.log(
+      `No files changed against ${BASE_BRANCH}; running all components.`,
+    );
+    return null;
+  }
+
+  const touched = new Set();
+  for (const file of changed) {
+    const component = fileToComponent(file);
+    if (component === 'unknown') {
+      console.log(
+        `Non-doc change detected (${file}); running all components.`,
+      );
+      return null;
+    }
+    touched.add(component);
+  }
+
+  const allComponents = await enumerateSourceComponents();
+  const toSkip = [];
+  for (const component of allComponents) {
+    if (touched.has(component)) continue;
+    toSkip.push({ component, variant: 'default' });
+    toSkip.push({ component, variant: 'dark' });
+  }
+
+  console.log(
+    `Touched ${touched.size} doc component(s); skipping ${toSkip.length / 2}.`,
+  );
+
+  return toSkip.length > 0 ? toSkip : null;
+}
+
+async function main() {
+  const passthroughArgs = process.argv.slice(2);
+  const skipList = await computeSkipList();
+
+  const happoArgs = [...passthroughArgs];
+  if (skipList) {
+    happoArgs.push('--skip', JSON.stringify(skipList));
+  }
+
+  const child = spawn('pnpm', ['exec', 'happo', ...happoArgs], {
+    stdio: 'inherit',
+  });
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+    } else {
+      process.exit(code ?? 1);
+    }
+  });
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add `runHappo.mjs` wrapper that diffs `HEAD` against `origin/main`, maps changed `.md(x)` files to their component names, and passes a `--skip` list to `happo` so only touched pages run
- Fall back to running every component when a non-doc file (config, css, `_partials`, `sidebars.json`, anything outside `docs/**` and `versioned_docs/version-*/**`) is part of the change, or when the diff can't be computed
- Update the Happo workflow to use `fetch-depth: 0`, explicitly fetch `origin main`, and invoke the wrapper instead of `pnpm happo`

Mapping examples: `docs/cli.mdx` → component `docs/cli`; `versioned_docs/version-legacy/cli.md` → component `docs/legacy/cli`. Both `default` and `dark` variants are skipped for untouched components.

Local `pnpm happo` still runs everything; use `node runHappo.mjs` locally for the skip-aware flow.

## Test plan
- [ ] Open a PR that only touches `docs/cli.mdx` and confirm the Happo run skips every component except `docs/cli`
- [ ] Open a PR that touches `docusaurus.config.js` (or any non-doc file) and confirm Happo runs every component
- [ ] Open a PR that touches `docs/_partials/*` and confirm Happo runs every component
- [ ] Confirm push-to-main runs full suite (empty diff → no skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)