### PR TITLE
docs: document --skip on Custom, Playwright, and Cypress pages

### DIFF
--- a/docs/custom.mdx
+++ b/docs/custom.mdx
@@ -204,6 +204,18 @@ command line.
 npx happo
 ```
 
+## Partial runs
+
+To exclude specific components or variants from a run, use the
+[`--skip`](cli#--skip-json) CLI option:
+
+```sh
+npx happo --skip '[{"component":"Card"},{"component":"Button"}]'
+```
+
+Any matching `registerExample` calls will be skipped during the run. See the
+[CLI reference](cli#--skip-json) for the full list of entry forms.
+
 ## Testing locally
 
 If you serve the custom folder (`./tmp/happo-custom` in our case) through an

--- a/docs/cypress.mdx
+++ b/docs/cypress.mdx
@@ -283,6 +283,18 @@ cy.happoHideDynamicElements({
 });
 ```
 
+## Partial runs
+
+To exclude specific components or variants from a run, pass the
+[`--skip`](cli#--skip-json) CLI option to the `happo` wrapper:
+
+```sh
+npx happo --skip '[{"component":"Card"},{"component":"Button"}]' -- cypress run
+```
+
+Any matching `happoScreenshot` calls will be skipped during the run. See the
+[CLI reference](cli#--skip-json) for the full list of entry forms.
+
 ## Continuous Integration
 
 If you run the test suite in a CI environment, the `happo` module will do its

--- a/docs/playwright.mdx
+++ b/docs/playwright.mdx
@@ -204,6 +204,18 @@ await happoScreenshot(heroImage, {
 "Footer" is now rendered in Chrome (target specified in `happo.config.ts`) and
 Firefox (dynamic target).
 
+## Partial runs
+
+To exclude specific components or variants from a run, pass the
+[`--skip`](cli#--skip-json) CLI option to the `happo` wrapper:
+
+```sh
+npx happo --skip '[{"component":"Card"},{"component":"Button"}]' -- playwright test
+```
+
+Any matching `happoScreenshot` calls will be skipped during the run. See the
+[CLI reference](cli#--skip-json) for the full list of entry forms.
+
 ## Continuous Integration
 
 If you run the test suite in a CI environment, the `happo` module will do its


### PR DESCRIPTION
## Summary
- Add a \"Partial runs\" section to the Custom, Playwright, and Cypress integration pages documenting the \`--skip\` CLI option.
- Storybook already documents both \`--only\` and \`--skip\` in its existing Partial runs section, so it is left unchanged.
- Examples use \`{component}\` entries only — skipping by variant is supported but rare, so it's not shown here.

## Test plan
- [ ] Preview the Custom, Playwright, and Cypress pages and verify the new section renders correctly and links to the CLI reference resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)