### PR TITLE
Document EntraID user assignment and guest/cross-tenant sign-in

### DIFF
--- a/docs/single-sign-on.md
+++ b/docs/single-sign-on.md
@@ -414,9 +414,29 @@ EntraID.
 
 #### Assign users to Happo application
 
-To allow people to sign in to Happo, you need to assign them to it. In the
-"Users & Groups" page of the Enterprise Application you created, add the users
-that you want to have access to Happo.
+By default, EntraID requires users to be explicitly assigned to the Enterprise
+Application before they can sign in. In the "Users & Groups" page of the
+Enterprise Application you created, add the users that you want to have access
+to Happo.
+
+If you'd rather let anyone in your directory sign in without assigning them
+individually, go to the **Properties** page of the Enterprise Application and
+set **Assignment required?** to **No**.
+
+#### Allowing guests and cross-tenant users
+
+Non-gallery Enterprise Applications are single-tenant by default
+(`signInAudience` is set to `AzureADMyOrg`), which means only native members of
+your tenant can sign in. Guests, B2B users, and users from federated tenants
+will be rejected with error `AADSTS650059`:
+
+> The application is not configured for use in the tenant. The value
+> AzureADMyOrg set for application property signInAudience is limiting its use
+> in the tenant.
+
+To allow these users in, open the underlying **App registration** for the
+application, go to **Manifest**, change `signInAudience` to
+`AzureADMultipleOrgs`, and save.
 
 ### Setup on the Happo side
 


### PR DESCRIPTION
## Summary

Extends the EntraID (Azure AD) section of the SSO docs to cover two defaults that have been tripping up customers setting up SAML SSO:

- **User assignment** — Enterprise Applications require explicit user assignment by default. The docs now point this out in the existing _Assign users to Happo application_ step, and note that admins can set _Assignment required?_ to _No_ under Properties if they prefer directory-wide access.
- **Guests / cross-tenant users** — new _Allowing guests and cross-tenant users_ subsection explaining that Non-gallery apps default to `signInAudience: AzureADMyOrg` (single tenant), which rejects guests and B2B users with `AADSTS650059`. Includes the fix: App registration → Manifest → `AzureADMultipleOrgs`.

Only the current docs version was updated; the `legacy` version is frozen.

## Test plan

- [x] Previewed the rendered page locally via `pnpm start` — both the updated _Assign users_ section and the new _Allowing guests and cross-tenant users_ subsection render correctly and match surrounding style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)