### PR TITLE
Use dynamic footer copyright year

### DIFF
--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -1,8 +1,4 @@
 {
-  "copyright": {
-    "message": "Copyright © 2024 Happo LLC",
-    "description": "The footer copyright"
-  },
   "link.title.Docs": {
     "message": "Docs",
     "description": "The title of the footer links column with title=Docs in the footer"


### PR DESCRIPTION
## Summary

Removes the static `copyright` override from `i18n/en/docusaurus-theme-classic/footer.json`. The footer now uses `themeConfig.footer.copyright` from `docusaurus.config.js`, which already sets the year with `new Date().getFullYear()` at build time.

## Why

The i18n string was overriding the config and pinning the year to 2024 in production bundles.

## Note

Running `docusaurus write-translations` may re-add a static `copyright` entry; delete that block again if you want the dynamic config value to apply.

Made with [Cursor](https://cursor.com)