### PR TITLE
CI: add SBOM and provenance attestations to Docker publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,8 +125,14 @@ jobs:
           command: |
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
             IMAGE_TAG=${CIRCLE_TAG/v/''}
-            docker build -t enduire/happo-docs:$IMAGE_TAG .
-            docker push enduire/happo-docs:$IMAGE_TAG
+            docker buildx create --use --name happo-builder --driver docker-container
+            docker buildx build \
+              --progress=plain \
+              -t enduire/happo-docs:$IMAGE_TAG \
+              --attest type=sbom \
+              --attest type=provenance,mode=max \
+              --push \
+              .
 workflows:
   version: 2.1
   run_all:


### PR DESCRIPTION
## Summary

- Switches `docker build` to `docker buildx build` with a dedicated `docker-container` driver builder (required since the default `docker` driver doesn't support attestations)
- Adds `--attest type=sbom` to generate a Software Bill of Materials (OS + npm packages via BuildKit's Syft integration)
- Adds `--attest type=provenance,mode=max` to attach SLSA provenance metadata

Mirrors the same change made in happo/happo-snap#1218.

## Test plan

- [ ] Trigger a release tag and confirm the published image on Docker Hub includes SBOM and provenance attestations

🤖 Generated with [Claude Code](https://claude.com/claude-code)