### PR TITLE
Fire Docs Visited Plausible event on every docs page view

### DIFF
--- a/src/clientModules/plausible.js
+++ b/src/clientModules/plausible.js
@@ -1,9 +1,63 @@
-// Lazy-load the tracker library only on the client
-if (typeof window !== 'undefined') {
-  import('@plausible-analytics/tracker').then(({ init }) => {
-    init({
-      domain: 'docs.happo.io',
-      captureOnLocalhost: false,
+// Lazy-load the tracker library only on the client and fire a "Docs Visited"
+// custom event for every page view under docs.happo.io. Pageviews are also
+// captured automatically by the tracker, but the custom event lets us use
+// "Docs Visited" as a top-of-funnel goal in Plausible.
+
+let trackerPromise;
+
+function getTracker() {
+  if (!trackerPromise) {
+    trackerPromise = import('@plausible-analytics/tracker').then(mod => {
+      if (!window.__happoPlausibleInitialized) {
+        mod.init({
+          domain: 'docs.happo.io',
+          captureOnLocalhost: false,
+        });
+        window.__happoPlausibleInitialized = true;
+      }
+      return mod;
     });
-  });
+  }
+  return trackerPromise;
+}
+
+function trackDocsVisited() {
+  getTracker()
+    .then(({ track }) => {
+      try {
+        track('Docs Visited', {
+          props: { path: window.location.pathname },
+        });
+      } catch (err) {
+        if (process.env.NODE_ENV !== 'production') {
+          // eslint-disable-next-line no-console
+          console.warn('Failed to track Docs Visited', err);
+        }
+      }
+    })
+    .catch(() => {
+      // Tracker failed to load (e.g. blocked); ignore.
+    });
+}
+
+if (typeof window !== 'undefined') {
+  // Kick off the tracker init eagerly so the first pageview is captured even
+  // if the route lifecycle below doesn't fire (older Docusaurus versions).
+  getTracker();
+}
+
+export function onRouteDidUpdate({ location, previousLocation }) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  // Only fire when the pathname actually changes (or on first load when
+  // previousLocation is null). Avoids double-firing on query/hash-only
+  // updates.
+  if (
+    previousLocation &&
+    previousLocation.pathname === location.pathname
+  ) {
+    return;
+  }
+  trackDocsVisited();
 }


### PR DESCRIPTION
## Summary

Companion to [happo/happo-view#3812](https://github.com/happo/happo-view/pull/3812) for [HAP-852](https://linear.app/happo/issue/HAP-852/configure-plausible-goals-utm-conventions-and-funnel-metrics).

Fires a `Docs Visited` Plausible custom event whenever the user lands on or navigates to a page under `docs.happo.io`. This lets us use docs visits as a top-of-funnel goal in Plausible (alongside `Pricing Viewed`, `Trial Signup`, etc.) so we can measure conversion rate by source rather than raw visits.

### Implementation

- Adds the `onRouteDidUpdate` client-module lifecycle hook so the event fires on both initial load and client-side route changes.
- Skips firing on hash/query-only changes (same `pathname` as previous).
- Sends `path` as a Plausible custom prop so we can break the event down by section of the docs.
- The Plausible tracker library is still lazy-loaded once and `init()` is called only once; subsequent navigations reuse the cached module via a memoized `getTracker()` promise.

## Test plan

- [ ] Build the site locally and confirm the event fires in Plausible's "test events" view on initial load and on client navigations
- [ ] Confirm no extra event fires on hash navigations within the same page

Made with [Cursor](https://cursor.com)