### PR TITLE
Document failOnWaitForTimeout behavior change

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -481,6 +481,35 @@ export default defineConfig({
 | `ignoreWhitespace` | `boolean`                   | `false`         | When `true`, whitespace-only differences are ignored.                                                                            |
 | `applyBlur`        | `boolean`                   | `false`         | When `true`, a blur is applied before comparing to smooth out subtle edge differences.                                           |
 
+## `failOnWaitForTimeout`
+
+_Available since happo v6.12.0._
+
+Controls how Happo workers react when a `waitForContent`, `waitForSelector`, or
+`waitFor` option times out before the expected content, selector, or condition
+appears. Defaults to `true`.
+
+- `true` (default) — the snap fails with a clear error. This surfaces stale
+  `waitForContent` strings, `waitForSelector` values, and `waitFor` predicates
+  immediately, so they can be fixed at the source instead of silently adding
+  multi-second waits to every run.
+- `false` — the timeout only emits a warning in the worker logs and the
+  screenshot is taken anyway against whatever happens to be on the page. This
+  is the legacy behavior.
+
+We recommend leaving this set to `true`. Set it to `false` as a temporary
+escape hatch while you investigate a failing run; the long-term fix is to
+update the offending wait so it matches the content that actually renders.
+
+```js title="happo.config.ts"
+import { defineConfig } from 'happo';
+
+export default defineConfig({
+  failOnWaitForTimeout: false,
+  // ... rest of config
+});
+```
+
 ## `integration`
 
 Specify the type of integration you're using with Happo. The integration type
@@ -700,7 +729,11 @@ Happo reports, so ensure it is unique for each page).
 
 Optionally, you can specify `waitForContent` to wait for specific content to
 appear on the page before taking the screenshot, or `waitForSelector` to wait
-for a selector to appear in the document before taking the screenshot.
+for a selector to appear in the document before taking the screenshot. If the
+content or selector does not appear within the worker's timeout, the snap
+fails by default. See
+[`failOnWaitForTimeout`](#failonwaitfortimeout) if you need to opt out of that
+behavior.
 
 **Note:** The URLs to the website need to be publicly available, otherwise Happo
 workers won't be able to access the pages.

--- a/docs/custom.mdx
+++ b/docs/custom.mdx
@@ -150,7 +150,12 @@ parameter might help.
 
 Let's assume that we have an example that needs to fetch some external data. In
 order to wait for the data to finish loading, we can add a `waitForContent`
-parameter with some unique string from the loaded state:
+parameter with some unique string from the loaded state.
+
+If the content does not appear within the worker's timeout, the snap fails by
+default. See
+[`failOnWaitForTimeout`](configuration.md#failonwaitfortimeout) if you need to
+opt out of that behavior.
 
 ```js title="main.js"
 happoCustom.registerExample({

--- a/docs/full-page.mdx
+++ b/docs/full-page.mdx
@@ -77,4 +77,40 @@ export default defineConfig({
 ```
 
 Happo will wait at most 10 seconds for the content to appear before it takes the
-screenshot.
+screenshot. If the content does not appear within that time, the snap fails by
+default. See
+[`failOnWaitForTimeout`](configuration.md#failonwaitfortimeout) if you need to
+opt out of that behavior.
+
+### `waitForSelector`
+
+If present, Happo will wait for a selector to appear in the document before
+taking the screenshot. For example:
+
+```js title="happo.config.ts"
+import { defineConfig } from 'happo';
+
+export default defineConfig({
+  apiKey: process.env.HAPPO_API_KEY,
+  apiSecret: process.env.HAPPO_API_SECRET,
+
+  integration: {
+    type: 'pages',
+    pages: [
+      {
+        url: 'https://example.com/products',
+        title: 'Products',
+        waitForSelector: '.product-list',
+      },
+    ],
+  },
+
+  // ... other configuration
+});
+```
+
+Happo will wait at most 10 seconds for the selector to appear before it takes
+the screenshot. If the selector does not appear within that time, the snap
+fails by default. See
+[`failOnWaitForTimeout`](configuration.md#failonwaitfortimeout) if you need to
+opt out of that behavior.

--- a/docs/migrating-from-legacy-packages.md
+++ b/docs/migrating-from-legacy-packages.md
@@ -529,6 +529,22 @@ Some target options changed:
 
 - `freezeAnimations` - now defaults to `'last-frame'`
 
+### Wait Timeouts Now Fail by Default
+
+Starting in happo v6.12.0, a `waitForContent`, `waitForSelector`, or `waitFor`
+that times out before the expected content, selector, or condition appears
+will fail the snap. In the legacy packages, a timeout only emitted a warning
+in the worker logs and the screenshot was taken anyway.
+
+If a run starts failing after migrating because of this, update the offending
+`waitForContent` / `waitForSelector` / `waitFor` so it matches what actually
+renders — this is almost always the right fix, since it also removes the
+multi-second wait that was running on every snap. As a temporary escape
+hatch, set
+[`failOnWaitForTimeout: false`](configuration.md#failonwaitfortimeout) in
+your `happo.config.{js,ts,...}` to restore the legacy warn-and-screenshot
+behavior while you investigate.
+
 ### Environment Variables
 
 The following environment variables have been removed and are no longer

--- a/docs/storybook.mdx
+++ b/docs/storybook.mdx
@@ -343,6 +343,11 @@ iframe that you have no control over, loading a credit card form. In order to
 wait for the iframe to finish, we can add a `waitForContent` parameter with some
 unique string in the iframe.
 
+If the content does not appear within the render timeout, the snap fails by
+default. See
+[`failOnWaitForTimeout`](configuration.md#failonwaitfortimeout) if you need to
+opt out of that behavior.
+
 ````mdx-code-block
 <Tabs>
   <TabItem value="csf" label="CSF" default>
@@ -375,6 +380,11 @@ storiesOf('PaymentForm', module).add('default', () => <PaymentForm />, {
 To make Happo wait with the screenshot until a condition has been met, use the
 `waitFor` option. Specify a function that returns `true` (or anything truthy)
 when the time is right to take the screenshot.
+
+If the condition does not become truthy within the render timeout, the snap
+fails by default. See
+[`failOnWaitForTimeout`](configuration.md#failonwaitfortimeout) if you need to
+opt out of that behavior.
 
 Here's an example that waits for a specific element (`.credit-card`) to appear:
 


### PR DESCRIPTION
## Summary

- Document the new top-level `failOnWaitForTimeout` config option (available since happo v6.12.0) and the new default of failing the snap when `waitForContent` / `waitForSelector` / `waitFor` times out.
- Update every page that mentions `waitForContent`, `waitForSelector`, or `waitFor` to call out the new default and link to the option: Storybook (waitForContent, waitFor), Custom (waitForContent), Pages — both inside the Pages Integration Options block in `configuration.md` and on the standalone Full-page page.
- Fix a pre-existing gap: the Full-page integration docs only documented `waitForContent` even though the Pages integration supports `waitForSelector` too. Added a matching section.
- Add a Breaking Changes entry to the legacy migration guide covering the behavior change and the upgrade guidance (fix the stale wait at its source; use `failOnWaitForTimeout: false` only as a temporary escape hatch).

Tied to https://github.com/happo/happo/pull/500 (HAP-894).

Skipped: `versioned_docs/version-legacy/` (option doesn't apply to the legacy package) and the README changelog (updated at release time).

## Test plan

- [ ] `pnpm build` succeeds and the new `failOnWaitForTimeout` anchor resolves from every cross-link
- [ ] Visual check that the new section sits cleanly between `deepCompare` and `integration` in the Configuration page
- [ ] Visual check that the new `waitForSelector` section on the Full-page page reads consistently with the existing `waitForContent` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)