### PR TITLE
Trigger production deploy on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,17 @@ jobs:
               --attest type=provenance,mode=max \
               --push \
               .
+
+      - run:
+          name: Trigger production deploy
+          command: |
+            VERSION=${CIRCLE_TAG/v/}
+            curl -fsS -X POST \
+              -H "Authorization: Bearer ${HAPPO_VIEW_KUBERNETES_DEPLOY_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/happo/happo-view-kubernetes/dispatches \
+              -d "{\"event_type\":\"docker-image-published\",\"client_payload\":{\"image\":\"enduire/happo-docs\",\"tag\":\"${VERSION}\"}}"
 workflows:
   version: 2.1
   run_all:


### PR DESCRIPTION
## Summary
- After `publish-docker` on `v*` tags, POST to `happo/happo-view-kubernetes` dispatches API to run the Auto deploy workflow for `enduire/happo-docs`

## Setup required before merge
Add **`HAPPO_VIEW_KUBERNETES_DEPLOY_TOKEN`** to the CircleCI **`docker`** context (Project Settings → Contexts): a fine-grained PAT with **Contents: Read and write** on `happo-view-kubernetes`. Read-only is not enough — the API returns "Resource not accessible by personal access token".

## Test plan
- [ ] Context variable configured in CircleCI
- [ ] Merge PR
- [ ] Next `v*` release triggers Auto deploy in happo-view-kubernetes without manual intervention