### PR TITLE
Document browser → type rename in dynamic targets

### DIFF
--- a/docs/cypress.mdx
+++ b/docs/cypress.mdx
@@ -209,14 +209,14 @@ In this example, the "Footer" snapshot will only be rendered in the target named
 ### Dynamic targets
 
 If you want to create a snapshot in a target that isn't defined in the
-`happo.config.ts` config, you can use an object with `name`, `browser` and
+`happo.config.ts` config, you can use an object with `name`, `type` and
 `viewport` properties. Here's an example where a snapshot is taken in a
 dynamically generated target:
 
 ```js
 cy.get('.footer').happoScreenshot({
   component: 'Footer',
-  targets: [{ name: 'firefox-small', browser: 'firefox', viewport: '400x800' }],
+  targets: [{ name: 'firefox-small', type: 'firefox', viewport: '400x800' }],
 });
 ```
 
@@ -229,7 +229,7 @@ cy.get('.footer').happoScreenshot({
   component: 'Footer',
   targets: [
     'chrome-small',
-    { name: 'firefox-small', browser: 'firefox', viewport: '400x800' },
+    { name: 'firefox-small', type: 'firefox', viewport: '400x800' },
   ],
 });
 ```

--- a/docs/migrating-from-legacy-packages.md
+++ b/docs/migrating-from-legacy-packages.md
@@ -155,6 +155,31 @@ export default defineConfig({
   (they use a fixed size)
 - `freezeAnimations` now defaults to `'last-frame'`
 
+#### Dynamic targets in Cypress/Playwright screenshots
+
+The dynamic target objects you can pass to a `happoScreenshot` call's
+`targets` option use the same renamed field — `browser` becomes `type`.
+
+**Before (legacy):**
+
+```js
+await happoScreenshot(heroImage, {
+  component: 'Footer',
+  variant: 'Default',
+  targets: [{ name: 'firefox-small', browser: 'firefox', viewport: '400x800' }],
+});
+```
+
+**After (new):**
+
+```js
+await happoScreenshot(heroImage, {
+  component: 'Footer',
+  variant: 'Default',
+  targets: [{ name: 'firefox-small', type: 'firefox', viewport: '400x800' }],
+});
+```
+
 ### Animations
 
 The previous default for stopping animations was to freeze them on the first

--- a/docs/playwright.mdx
+++ b/docs/playwright.mdx
@@ -174,7 +174,7 @@ In this example, the "Footer" snapshot will only be rendered in the target named
 ### Dynamic targets
 
 If you want to create a snapshot in a target that isn't defined in the
-`happo.config.ts` config, you can use an object with `name`, `browser` and
+`happo.config.ts` config, you can use an object with `name`, `type` and
 `viewport` properties. Here's an example where a snapshot is taken in a
 dynamically generated target:
 
@@ -182,7 +182,7 @@ dynamically generated target:
 await happoScreenshot(heroImage, {
   component: 'Footer',
   variant: 'Default',
-  targets: [{ name: 'firefox-small', browser: 'firefox', viewport: '400x800' }],
+  targets: [{ name: 'firefox-small', type: 'firefox', viewport: '400x800' }],
 });
 ```
 
@@ -196,7 +196,7 @@ await happoScreenshot(heroImage, {
   variant: 'Default',
   targets: [
     'chrome-small',
-    { name: 'firefox-small', browser: 'firefox', viewport: '400x800' },
+    { name: 'firefox-small', type: 'firefox', viewport: '400x800' },
   ],
 });
 ```


### PR DESCRIPTION
## Summary
- Add a subsection to the migration guide noting that the per-screenshot `targets` array passed to `happoScreenshot` follows the same `browser` → `type` rename as the main `targets` config.
- Fix the Cypress and Playwright docs (new library) which still showed `browser` in their "Dynamic targets" examples.

## Test plan
- [ ] Build the docs site and confirm the new "Dynamic targets in Cypress/Playwright screenshots" subsection renders under "Target Configuration" on the migration page.
- [ ] Confirm the Cypress and Playwright "Dynamic targets" sections now show `type: 'firefox'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)