### PR TITLE
Set pnpm minimumReleaseAge to 2 days to match Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     directory: '/'
     schedule:
       interval: daily
+    cooldown:
+      default-days: 2
     groups:
       babel:
         patterns:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,3 +14,12 @@ strictPeerDependencies: false
 autoInstallPeers: true
 savePrefix: ''
 dedupePeerDependents: true
+
+# Match dependabot npm cooldown (default-days: 2 in .github/dependabot.yml)
+minimumReleaseAge: 2880
+
+# Bypass minimumReleaseAge for packages we publish ourselves, so we can
+# install fresh versions immediately after release.
+minimumReleaseAgeExclude:
+  - happo
+  - release-with-ease


### PR DESCRIPTION
## Summary
- Set `minimumReleaseAge` to 2880 minutes (2 days) in `pnpm-workspace.yaml` to align with Dependabot npm cooldown.
- Also sets Dependabot `cooldown` for npm. Excludes `happo` and `release-with-ease` from pnpm minimum release age.

## Test plan
- [ ] `pnpm install` succeeds

Made with [Cursor](https://cursor.com)