### PR TITLE
Add docs for the Happo MCP server

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,71 @@
+---
+id: mcp
+title: MCP server
+---
+
+Happo runs an [MCP](https://modelcontextprotocol.io/) server that lets AI
+assistants help you manage your visual-regression comparisons. With it,
+assistants like Claude, ChatGPT, and Cursor can list comparisons for a commit,
+inspect diffs, and approve, reject, or report flake on your behalf.
+
+The server uses the "Streamable HTTP" transport with OAuth 2.1 authentication,
+so connecting only requires a single URL. The endpoint is:
+
+```
+https://happo.io/api/mcp
+```
+
+Clients automatically discover the OAuth endpoints through
+`/.well-known/oauth-protected-resource`, so you don't need to configure tokens
+manually.
+
+## Available tools
+
+The MCP server exposes the following tools:
+
+- **`list_comparisons_for_sha`** — retrieves all comparisons linked to a
+  specific commit SHA.
+- **`get_comparison_details`** — returns the complete diffs and snapshot
+  information between two reports.
+- **`approve_comparison` / `reject_comparison`** — resolves a pending review
+  after inspecting the differences.
+- **`report_flake`** — marks a spurious diff as a
+  [flake](reporting-flake.md) and records attribution.
+
+## Setup
+
+### Claude Code
+
+Run the following command from your terminal:
+
+```sh
+claude mcp add --transport http happo https://happo.io/api/mcp
+```
+
+Authorization happens during the first tool use.
+
+### Claude Desktop
+
+Go to **Settings → Connectors → "Add custom connector"** and paste the MCP URL:
+
+```
+https://happo.io/api/mcp
+```
+
+### Cursor
+
+Configure the server in `~/.cursor/mcp.json` (global) or `.cursor/mcp.json`
+(project-specific):
+
+```json
+{ "mcpServers": { "happo": { "url": "https://happo.io/api/mcp" } } }
+```
+
+Then reload Cursor or toggle the server under **Settings → Features → Model
+Context Protocol**.
+
+## Permissions
+
+Connected accounts inherit your permissions, and all actions are attributed to
+your user. You can revoke access at any time through the **Connected
+applications** section on the [API tokens page](https://happo.io/account).

--- a/sidebars.json
+++ b/sidebars.json
@@ -4,6 +4,7 @@
       "getting-started",
       "continuous-integration",
       "api",
+      "mcp",
       "webhooks",
       "cli",
       "browsers"


### PR DESCRIPTION
## Summary
- Add `docs/mcp.md` documenting the Happo MCP server: endpoint, available tools (`list_comparisons_for_sha`, `get_comparison_details`, `approve_comparison`/`reject_comparison`, `report_flake`), client setup (Claude Code, Claude Desktop, Cursor), and permissions
- Register the new page in the Overview section of `sidebars.json`, after `api`

Based on the content at https://happo.io/docs/mcp.

## Test plan
- [ ] Run the docs site locally and confirm the new "MCP server" page renders and appears in the Overview sidebar
- [ ] Verify links to the reporting-flake page and API tokens page resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)