### PR TITLE
Document data-happo-focus-visible attribute

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -282,9 +282,10 @@ export default defineConfig({
 *Available since happo v6.0.0.*
 
 When set to `true`, this option allows you to add `data-happo-hover`,
-`data-happo-focus`, and `data-happo-active` attributes to your DOM elements and
-have Happo apply the corresponding `:hover`, `:focus`, or `:active` styles. For
-example, if you have this markup:
+`data-happo-focus`, `data-happo-focus-visible`, and `data-happo-active`
+attributes to your DOM elements and have Happo apply the corresponding `:hover`,
+`:focus`, `:focus-visible`, or `:active` styles. For example, if you have this
+markup:
 
 ```html
 <button>Hover me</button>
@@ -312,6 +313,31 @@ Similarly, you can add focus to elements using `data-happo-focus`:
 ```html
 <input type="text" data-happo-focus />
 ```
+
+`data-happo-focus` focuses the element the same way a mouse click or a
+programmatic `element.focus()` call does, which means `:focus` styles are
+applied but `:focus-visible` styles are **not**.
+
+To capture the focus ring that keyboard users see, use
+`data-happo-focus-visible` instead. It focuses the element as if the user had
+tabbed to it, so both `:focus` and `:focus-visible` styles are applied:
+
+```html
+<button data-happo-focus-visible>Tab to me</button>
+<style>
+  button:focus {
+    background-color: lightblue;
+  }
+  button:focus-visible {
+    outline: 2px solid blue;
+  }
+</style>
+```
+
+Use one or the other on a given snapshot — since only one element can hold focus
+at a time, Happo focuses the first element it finds with `data-happo-focus`,
+then the first element with `data-happo-focus-visible`, so the latter wins if
+both are present.
 
 And add `data-happo-active` to elements to simulate the `:active` state:
 
@@ -719,9 +745,18 @@ export default defineConfig({
 > **Experimental**
 
 When set to `true`, Happo automatically collects and represents `:focus`,
-`:focus-visible`, `:active`, and `:hover` states in screenshots. This lets you
-capture interactive states without manually adding `data-happo-*` attributes to
+`:focus-visible`, `:active`, and `:hover` states in screenshots. At snapshot
+time, elements that are currently in one of those states get the corresponding
+`data-happo-hover`, `data-happo-active`, and `data-happo-focus-visible`
+attribute added for you. This lets you capture interactive states — including
+the keyboard focus ring — without manually adding `data-happo-*` attributes to
 your markup.
+
+**Note:** Basic focus handling (`data-happo-focus`, based on the document's
+active element) is always applied, regardless of this option. Enabling
+`autoApplyPseudoStateAttributes` additionally traverses into shadow DOM to find
+the deepest focused element, and distinguishes keyboard focus
+(`data-happo-focus-visible`) from other focus.
 
 This option requires the
 [`applyPseudoClasses` target option](#target-applypseudoclasses).

--- a/versioned_docs/version-legacy/configuration.md
+++ b/versioned_docs/version-legacy/configuration.md
@@ -186,9 +186,10 @@ module.exports = {
 ### Target `applyPseudoClasses`
 
 When set to `true`, this option allows you to add `data-happo-hover`,
-`data-happo-focus`, and `data-happo-active` attributes to your DOM elements and
-have Happo apply the corresponding `:hover`, `:focus`, or `:active` styles. For
-example, if you have this markup:
+`data-happo-focus`, `data-happo-focus-visible`, and `data-happo-active`
+attributes to your DOM elements and have Happo apply the corresponding `:hover`,
+`:focus`, `:focus-visible`, or `:active` styles. For example, if you have this
+markup:
 
 ```html
 <button>Hover me</button>
@@ -216,6 +217,31 @@ Similarly, you can add focus to elements using `data-happo-focus`:
 ```html
 <input type="text" data-happo-focus />
 ```
+
+`data-happo-focus` focuses the element the same way a mouse click or a
+programmatic `element.focus()` call does, which means `:focus` styles are
+applied but `:focus-visible` styles are **not**.
+
+To capture the focus ring that keyboard users see, use
+`data-happo-focus-visible` instead. It focuses the element as if the user had
+tabbed to it, so both `:focus` and `:focus-visible` styles are applied:
+
+```html
+<button data-happo-focus-visible>Tab to me</button>
+<style>
+  button:focus {
+    background-color: lightblue;
+  }
+  button:focus-visible {
+    outline: 2px solid blue;
+  }
+</style>
+```
+
+Use one or the other on a given snapshot — since only one element can hold focus
+at a time, Happo focuses the first element it finds with `data-happo-focus`,
+then the first element with `data-happo-focus-visible`, so the latter wins if
+both are present.
 
 And add `data-happo-active` to elements to simulate the `:active` state:
 


### PR DESCRIPTION
## What changed

Documents the `data-happo-focus-visible` attribute, which the Happo workers have supported since happo-snap 20.8.0 but which was never documented.

**`docs/configuration.md`**

- **`applyPseudoClasses`**: added `data-happo-focus-visible` to the intro list of supported attributes, plus a new subsection explaining the difference between the two focus attributes:
  - `data-happo-focus` focuses the element the way a mouse click or programmatic `element.focus()` does, so `:focus` applies but `:focus-visible` does **not**.
  - `data-happo-focus-visible` focuses as if the user tabbed to the element, so both `:focus` and `:focus-visible` apply.

  Includes an example and a note that `data-happo-focus-visible` wins if both attributes are present, since only one element can hold focus at a time.
- **`integration.autoApplyPseudoStateAttributes`**: spelled out which attributes are added automatically (`data-happo-hover`, `data-happo-active`, `data-happo-focus-visible`), and noted that basic `data-happo-focus` handling always happens regardless of the option, while enabling it adds shadow-DOM traversal and the keyboard-focus distinction.

**`versioned_docs/version-legacy/configuration.md`**

Same `applyPseudoClasses` update. The behavior is worker-side, so it applies to legacy runs too.

## Why

The attribute is the only way to capture the focus ring keyboard users actually see, and the `data-happo-focus` vs `:focus-visible` distinction is surprising enough to be worth stating explicitly.

## Notes for reviewers

- The wording is based on the implementation in `happo-snap`'s `PlaywrightBrowser.js` (`applyFocusPseudoClasses`) and `happo`'s `takeDOMSnapshot.ts` (`PSEUDO_STATE_ATTRS`), and matches the assertions in happo-snap's `focus-test.js`.
- No "*Available since happo vX*" marker was added, since the feature lives in the workers rather than the `happo` npm package.
- `applyPseudoClasses` only takes effect in the Playwright-driven targets — `IOSSafariBrowser.js` has no pseudo-class handling. That gap is undocumented for all the `data-happo-*` state attributes, not just this one, so it was left alone here rather than caveating a single attribute. Happy to document it for the whole section in a follow-up if that seems worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)